### PR TITLE
Fixed indentation problem with empty nodes containing xmlns

### DIFF
--- a/jquery.format.js
+++ b/jquery.format.js
@@ -118,7 +118,7 @@
 			this.shift = createShiftArr(this.step);
 		},
 
-		xml: function(text) {
+		xml: function (text) {
 			var ar = text.replace(/>\s{0,}</g,"><")
 						 .replace(/</g,"~::~<")
 						 .replace(/\s*xmlns\:/g,"~::~xmlns:")
@@ -163,6 +163,15 @@
 				if(ar[ix].search(/<\//) > -1) {
 					str = !inComment ? str += this.shift[--deep]+ar[ix] : str += ar[ix];
 				} else
+			    // xmlns //
+				if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) {
+				    str += this.shift[deep]+ar[ix];
+
+				    // xmlns=''/>
+				    if (ar[ix].search(/\/>/) > -1) {
+				        deep--;
+				    }
+				} else
 				// <elm/> //
 				if(ar[ix].search(/\/>/) > -1 ) {
 					str = !inComment ? str += this.shift[deep]+ar[ix] : str += ar[ix];
@@ -170,12 +179,7 @@
 				// <? xml ... ?> //
 				if(ar[ix].search(/<\?/) > -1) {
 					str += this.shift[deep]+ar[ix];
-				} else
-				// xmlns //
-				if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) {
-					str += this.shift[deep]+ar[ix];
 				}
-
 				else {
 					str += ar[ix];
 				}


### PR DESCRIPTION
Xml that was causing problem:

'<Root xmlns="test1" xmlns:i="test2"><Id xmlns="test3">773b5a19-f9f9-40a3-89cc-56ce316923cb</Id><Items/><Version i:nil="true" xmlns:a="test"/></Root>'

Ensure to parse for xmlns=''/> before <elm/> to update indentation properly since xmlns are already indented
